### PR TITLE
Fix for weekly report inactive user count

### DIFF
--- a/app/controllers/api/v1/social_attempts.rb
+++ b/app/controllers/api/v1/social_attempts.rb
@@ -17,13 +17,15 @@ module API
                 desc "Create new attempt"
                 post do
                     current_user = User.find_by(authentication_token: headers['Token'])
+                    save_activity(current_user)
                     if SocialAttempt.create!(user_id: current_user.id, description: "", created_at: Date.today)
                         render json: {
                             messages: "Attempt",
                             is_success: true,
                             status: :ok
-                        }
+                        } 
                     end
+                    
                 end
             end
 

--- a/app/controllers/api/v1/viewings.rb
+++ b/app/controllers/api/v1/viewings.rb
@@ -20,7 +20,7 @@ module API
                 status: :ok
               }
           end
-          save_activity(@current_user)
+          save_activity(current_user)
         end
       end 
 

--- a/app/jobs/active_users_job.rb
+++ b/app/jobs/active_users_job.rb
@@ -3,7 +3,9 @@ class ActiveUsersJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-    active_users = UserActivity.where('active_count > 0').count
+    active_users = UserActivity.select(:user_id)
+                               .where("active_count > :active_count and created_at >= :created_at and created_at < :end_date",
+                               {active_count: 0, created_at: Date.today-1, end_date: Date.today}).uniq.count
     stats = Stat.new
     stats.event_stat = active_users
     stats.description = 'Number of active users'

--- a/app/jobs/inactive_users_job.rb
+++ b/app/jobs/inactive_users_job.rb
@@ -3,7 +3,13 @@ class InactiveUsersJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-    inactive_users = UserActivity.where('active_count = 0').count
+    #Daily count of inactive users
+    active_users = UserActivity.select(:user_id)
+                              .where("active_count > :active_count and created_at >= :created_at and created_at < :end_date",
+                              {active_count: 0, created_at: Date.today-1, end_date: Date.today }).uniq.count
+    total_users = User.count
+    
+    inactive_users = total_users - active_users 
     stats = Stat.new
     stats.event_stat = inactive_users
     stats.description = 'Number of inactive users'
@@ -11,6 +17,8 @@ class InactiveUsersJob < ApplicationJob
     weekday = Date.today.strftime('%A') 
     stats.day = weekday
     stats.save
+
+
 		
 	#InactiveUsersJob.set(wait: 1.day).perform_later()
   end

--- a/app/jobs/new_users_job.rb
+++ b/app/jobs/new_users_job.rb
@@ -4,7 +4,8 @@ class NewUsersJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-	new_users_count = User.where('created_at >= ?', 1.days.ago).count
+	new_users_count = User.where("created_at >= :created_at and created_at < :end_date",
+                        {created_at: Date.today-1, end_date: Date.today }).count
 	stats = Stat.new
 	stats.event_stat = new_users_count
 	stats.description = 'New users'

--- a/app/jobs/number_of_attempted_shares_to_social_media_job.rb
+++ b/app/jobs/number_of_attempted_shares_to_social_media_job.rb
@@ -4,7 +4,8 @@ class NumberOfAttemptedSharesToSocialMediaJob < ApplicationJob
   def perform(*args)
     # Do something later
     
-    social_attempt = SocialAttempt.where('created_at >= ?', 1.days.ago).count
+    social_attempt = SocialAttempt.where("created_at >= :created_at and created_at < :end_date",
+																	{created_at: Date.today-1, end_date: Date.today }).count
 	  stats = Stat.new
 	  stats.event_stat = social_attempt
 	  stats.description = 'Number of attempted shares'

--- a/app/jobs/total_number_of_new_social_posts_job.rb
+++ b/app/jobs/total_number_of_new_social_posts_job.rb
@@ -3,7 +3,8 @@ class TotalNumberOfNewSocialPostsJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-	new_social_posts = SocialPost.where('created_at >= ?', 1.days.ago).count
+	new_social_posts = SocialPost.where("created_at >= :created_at and created_at < :end_date",
+														  	{created_at: Date.today-1, end_date: Date.today }).count
 	stats = Stat.new
 	stats.event_stat = new_social_posts
 	stats.description = 'Number of new social posts'
@@ -23,5 +24,5 @@ class TotalNumberOfNewSocialPostsJob < ApplicationJob
 
 
 
-end
+ end
 end

--- a/app/jobs/total_number_of_social_interactions_job.rb
+++ b/app/jobs/total_number_of_social_interactions_job.rb
@@ -3,8 +3,10 @@ class TotalNumberOfSocialInteractionsJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-    new_comments_count = Comment.where('created_at >= ?', 1.days.ago).count
-    new_bumps_count = PostBump.where('created_at >= ?', 1.days.ago).count
+    new_comments_count = Comment.where("created_at >= :created_at and created_at < :end_date",
+                                {created_at: Date.today-1, end_date: Date.today }).count
+    new_bumps_count = PostBump.where("created_at >= :created_at and created_at < :end_date",
+                              {created_at: Date.today-1, end_date: Date.today }).count
     total_interactions = new_comments_count + new_bumps_count
     
     stats = Stat.new

--- a/app/jobs/weekly_report_job.rb
+++ b/app/jobs/weekly_report_job.rb
@@ -3,117 +3,139 @@ class WeeklyReportJob < ApplicationJob
 
   def perform(*args)
     # Do something later
-    
+    #calculates weekly stats from Sunday to Saturday of the week
+    today = Date.today
+    #sunday start of last week 
+    start_of_last_week =  today.last_week+6.days
+    #saturday end of week last week
+    end_of_last_week = today.last_week+12.days 
+    #When report is ran on Sunday
+    next_start_day = today.last_week+7.days
+    next_end_day = today.last_week+13.days 
+
     #Total Users
-    total_users_count_weekly = User.count
+    total_users_count_weekly = User.where("created_at <= :created_at",
+                                   {created_at: end_of_last_week}).count
     weekly_stats = WeeklyStat.new
 	  weekly_stats.event_stat = total_users_count_weekly
-	  weekly_stats.description = 'Total Number of Users'
-	  weekly_stats.created_at = Date.today
+	  weekly_stats.description = "Total Number of Users"
+	  weekly_stats.created_at = today
 	  weekly_stats.save
 
 
     #New Users
-    new_users_count_weekly = User.where('created_at > ?', Date.today-1.week).count
+    new_users_count_weekly = User.where("created_at >= :start_date AND created_at <= :end_date",
+                                 {start_date: start_of_last_week, end_date: end_of_last_week}).count
     weekly_stats = WeeklyStat.new
 	  weekly_stats.event_stat = new_users_count_weekly
-	  weekly_stats.description = 'Number of new users this week'
-	  weekly_stats.created_at = Date.today
+	  weekly_stats.description = "Number of new users this week"
+	  weekly_stats.created_at = today
 	  weekly_stats.save
 
 
     #Active Users
     active_users_stat = UserActivity.select(:user_id)
-    .where(["active_count > :active_count and created_at > :created_at",
-    { active_count: 0, created_at: Date.today-1.week }]).uniq.count
+                                    .where(["active_count > :active_count AND created_at >= :start_date AND created_at <= :end_date",
+                                    {active_count: 0, start_date: start_of_last_week, end_date: end_of_last_week}]).uniq.count
     weekly_stats = WeeklyStat.new
     weekly_stats.event_stat = active_users_stat
-    weekly_stats.description = 'Number of active users this week'
-    weekly_stats.created_at = Date.today
+    weekly_stats.description = "Number of active users this week"
+    weekly_stats.created_at = today
     weekly_stats.save
 
     
     #Inactive Users
-    inactive_users_this_week = UserActivity.select(:user_id)
-    .where(["created_at < :created_at",
-    {created_at: Date.today-1.week }]).uniq.count
+    inactive_users_this_week = total_users_count_weekly - active_users_stat
+    # UserActivity.select(:user_id)
+    # .where(["created_at < :created_at",
+    # {created_at: Date.today-1.week }]).uniq.count
     weekly_stats = WeeklyStat.new
     weekly_stats.event_stat = inactive_users_this_week
-    weekly_stats.description = 'Number of inactive users this week'
-    weekly_stats.created_at = Date.today
+    weekly_stats.description = "Number of inactive users this week"
+    weekly_stats.created_at = today
     weekly_stats.save
 
 
     #Number of videos watched this week
-    videos_viewed = Viewing.select('DISTINCT video_id')
-    .where('viewings.created_at > ?', Date.today-1.week).count
+    videos_viewed = Viewing.select("DISTINCT video_id")
+                           .where("viewings.created_at >= :start_date AND viewings.created_at <= :end_date",
+                           {start_date: start_of_last_week, end_date: end_of_last_week}).count
 	  weekly_stats = WeeklyStat.new
 	  weekly_stats.event_stat = videos_viewed
-	  weekly_stats.description = 'Number of videos watched this week'
-	  weekly_stats.created_at = Date.today
+	  weekly_stats.description = "Number of videos watched this week"
+	  weekly_stats.created_at = today
 	  weekly_stats.save
 
 
     #Three most watched videos this week
     videos_watched = Viewing.joins("INNER JOIN videos ON videos.id = viewings.video_id")
-    .select('videos.title, SUM(viewings.last_second_viewed) AS time_viewed')
-    .where('viewings.created_at > ?', Date.today-1.week)
-    .group('videos.title')
-    .order('SUM(viewings.last_second_viewed) desc limit 3')
+                            .select("videos.title, SUM(viewings.last_second_viewed) AS time_viewed")
+                            .where("viewings.created_at >= :start_date AND viewings.created_at <= :end_date",
+                            {start_date: start_of_last_week, end_date: end_of_last_week})
+                            .group("videos.title")
+                            .order("SUM(viewings.last_second_viewed) desc limit 3")
     videos =[]
     videos_watched.each do |row|
     	videos << row.title
 	  end
     weekly_stats = WeeklyStat.new
     weekly_stats.event_stat = videos.join(", ")
-    weekly_stats.description = 'Top 3 most watched videos of the week'
-    weekly_stats.created_at = Date.today
-    weekly_stats.save   
+    weekly_stats.description = "Top 3 most watched videos of the week"
+    weekly_stats.created_at = today
+    weekly_stats.save
 
 
     #Most Active Day  of the Week
-    most_active = Stat.where('created_at > ? and description = ?', Date.today-1.week, 'Number of active users')
-    .limit(1).order('active_count desc')
+    #count starts on next day
+    most_active = Stat.where("created_at >= :start_date AND created_at <= :end_date AND description = :description",
+                      {start_date: next_start_day, end_date: next_end_day, description:"Number of active users"})
+                      .limit(1).order("CAST(event_stat AS int) desc , created_at desc")
     weekly_stats = WeeklyStat.new
     weekly_stats.description = "Most active day of the week"
     most_active.each do |row|
-      weekly_stats.event_stat = row.day
+      record_date = Date.parse(row.day).wday
+      actual_date_int = record_date-1
+      weekly_stats.event_stat = Date::DAYNAMES[actual_date_int]
     end
-    weekly_stats.created_at = Date.today
+    weekly_stats.created_at = today
     weekly_stats.save
 
 
     #Social Posts
-    new_social_posts_weekly = SocialPost.where('created_at > ?', Date.today-1.week).count
+    new_social_posts_weekly = SocialPost.where("created_at >= :start_date AND created_at <= :end_date",
+                                        {start_date: start_of_last_week, end_date: end_of_last_week}).count
     weekly_stats = WeeklyStat.new
     weekly_stats.event_stat = new_social_posts_weekly
-    weekly_stats.description = 'Social Posts'
-    weekly_stats.created_at = Date.today
+    weekly_stats.description = "Social Posts"
+    weekly_stats.created_at = today
     weekly_stats.save
 
 
     #Social Interactions
-    total_social_interactions_weekly = Stat.where(["description = :description and created_at > :created_at", { description:"Total Number of Interactions", created_at: Date.today-1.week }])
-    .sum('CAST(event_stat AS int)')
+    total_social_interactions_weekly = Stat.where("created_at >= :start_date AND created_at <= :end_date AND description = :description",
+                                           {start_date: next_start_day, end_date: next_end_day, description:"Total Number of Interactions"})
+                                           .sum('CAST(event_stat AS int)')
+                                      
     weekly_stats = WeeklyStat.new
     weekly_stats.event_stat = total_social_interactions_weekly
-    weekly_stats.description = 'Social Interactions'
-    weekly_stats.created_at = Date.today
+    weekly_stats.description = "Social Interactions"
+    weekly_stats.created_at = today
     weekly_stats.save
    
     
 
     #Social Attempts or External Shares
-    social_attempt_weekly = SocialAttempt.where('created_at > ?', Date.today-1.week).count
+    social_attempt_weekly = SocialAttempt.where("created_at >= :start_date AND created_at <= :end_date",
+                                          {start_date: start_of_last_week, end_date: end_of_last_week}).count
 	  weekly_stats = WeeklyStat.new
 	  weekly_stats.event_stat = social_attempt_weekly
-	  weekly_stats.description = 'External Shares'
-	  weekly_stats.created_at = Date.today
+	  weekly_stats.description = "External Shares"
+	  weekly_stats.created_at = today
 	  weekly_stats.save
 
 
     #Report Message Compostition
-    stats_weekly = WeeklyStat.where('created_at > ?', Date.today-1.week)
+    stats_weekly = WeeklyStat.where("created_at = :start_date",{start_date: today})
     message = "<ol>"
     stats_weekly.each do |wstat|
       stat_desc = wstat.description
@@ -125,7 +147,7 @@ class WeeklyReportJob < ApplicationJob
 
 
     #Call UserMailer
-    subject = "Weekly Report for #{Date.today-1.week} to #{Date.today}"       
+    subject = "Weekly Report for #{start_of_last_week} to #{end_of_last_week}"       
     UserMailer.report_message(subject,message).deliver
     
          

--- a/lib/tasks/guru.rake
+++ b/lib/tasks/guru.rake
@@ -50,8 +50,8 @@ namespace :guru do
   desc 'Runs: Weekly Report'
   #Runs weekly stats
   task weekly_report: [:environment] do
-    #Will run every Saturday
-    if Date.today.wday == 6 
+    #Will run every Sunday
+    if Date.today.wday == 7
       WeeklyReportJob.perform_now
     end 
   end


### PR DESCRIPTION
Release notes: Task1 Fix 
Aug 25, 2021

*Issue raised:
  Weekly Email Stat Issue
  Incorrect Calculations of Inactive Users


*Fix Applied
 Revised logic that computes Inactive Users 

*Other Enhancements: 
 Changed 'where query conditions' to avoid duplicate entries
 -applied to daily stats and the weekly stats report 
 -rewrote conditions to have consistent syntax

Notes: 
 The report will collect data from Sunday to Saturday
 Moved report generation date to Sunday. 
 Updated the activejobs and guru.rake files to reflect changes.  